### PR TITLE
Added AdditionalItemData class to the Item data type.

### DIFF
--- a/Data/Items/Item.cs
+++ b/Data/Items/Item.cs
@@ -16,4 +16,9 @@ namespace KoalaDev.UGIS
         #endregion
     }
     
+    [Serializable]
+    public abstract class AdditionalItemData
+    {
+        
+    }
 }


### PR DESCRIPTION
Whilst not linked in any way to the Item data type, it's related and it makes sense to keep this class on the Item class, with it being extended for the different Item types when / if required.

Closes #17 

Changes
---
- Added AdditionalItemData to the Base Item Script, which will allow for storing runtime data for the related item, as well as serialization to JSON with ease.