### PR TITLE
Added Container Item Sub-class

### DIFF
--- a/Data/Items/Base Types.meta
+++ b/Data/Items/Base Types.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 595fad03947ae9946bff8c8ffaa0283a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Data/Items/Base Types/Container.cs
+++ b/Data/Items/Base Types/Container.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace KoalaDev.UGIS.Items
+{
+    public abstract class Container : Item
+    {
+        // This sub-class of Item allows for items to have their own storage. Useful for clothing, or... Containers!
+        
+        #region --- VARIABLES ---
+        
+        public Vector2Int itemStorageSize;
+
+        // List of items that aren't permitted inside the container.
+        public Item[] itemBlacklist;
+        
+        // Makes itemBlacklist a whitelist, meaning only items in the list can be added.
+        public bool blacklistIsWhitelist; 
+
+        #endregion
+    }
+
+}

--- a/Data/Items/Base Types/Container.cs.meta
+++ b/Data/Items/Base Types/Container.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99ec58f180650dd459edf9bfda9ddb25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This item type allows for items to have their own inventory grid, however this will mostly be handled in the front-end.

Closes #10 

Additions
---
- Added Container : Item which has the necessary information to have items with their own containers
  - **ItemBlacklist** array was added to class to allow for containers to only accept certain items, this certainly isn't an "end-all" solution, but should still be helpful
  - **blacklistToWhitelist** bool used to convert ItemBlacklist into a whitelist.