### PR TITLE
11_Added Stackable Item Type & Updated Container Item Type

### DIFF
--- a/Data/Items/Base Types/Container.cs
+++ b/Data/Items/Base Types/Container.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace KoalaDev.UGIS.Items
@@ -17,6 +18,12 @@ namespace KoalaDev.UGIS.Items
         public bool blacklistIsWhitelist; 
 
         #endregion
+    }
+
+    [Serializable]
+    public abstract class ContainerItemData : AdditionalItemData
+    {
+        private InventoryGrid containerGrid;
     }
 
 }

--- a/Data/Items/Base Types/Stackable.cs
+++ b/Data/Items/Base Types/Stackable.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+
+namespace KoalaDev.UGIS.Items
+{
+    public abstract class Stackable : Item
+    {
+        /*
+         * This sub-class makes an item stackable, this is kept separate from Item due to conflicts with Container and
+         * Durability. Currently thinking about making a ComplexStackable item that supports Containers and Durability
+         * but this is not coming soon. I'm sure you can figure it out, but i'd probably just use a List to represent
+         * a stack of items, all of which can be durable or containers without issue.
+         */
+        #region --- VARIABLES ---
+
+        public int stackCapacity;
+
+        #endregion
+    }
+
+    [Serializable]
+    public abstract class StackableItemData : AdditionalItemData
+    {
+        public int currentStackCount;
+    }
+}

--- a/Data/Items/Base Types/Stackable.cs.meta
+++ b/Data/Items/Base Types/Stackable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dd2057d39160e945a825a78ab8923b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Stackable item type has been added allowing for their creation. StackableItemData was also created in the same file to allow for serializing run-time stack data. ContainerItemData was also added to allow the serialization of run-time container data.

Closes #11

Additions
---
- Stackable : Item that allows to be stacked to a set limt
- StackableItemData : AdditionalItemData that allows for the storing and serialization of run-time stack data.
- ContainerItemData : AdditionalItemData that allows for the storing and serialization of run-time container data.