### PR TITLE
Created Damageable Item Type

### DIFF
--- a/Data/Items/Base Types/Damageable.cs
+++ b/Data/Items/Base Types/Damageable.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace KoalaDev.UGIS.Items
+{
+    public class Damageable : Item
+    {
+        #region --- VARIABLES ---
+
+        public int maxDurability = 100;
+
+        #endregion
+    }
+
+    [Serializable]
+    public abstract class DamageableItemData : AdditionalItemData
+    {
+        public float currentDurability;
+    }
+
+}

--- a/Data/Items/Base Types/Damageable.cs.meta
+++ b/Data/Items/Base Types/Damageable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b22ae1dc601bb3941a6ab33c95e4e518
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Examples/Items/Backpack.asset
+++ b/Examples/Items/Backpack.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a44a4f12dcc5d640a347266abed311e, type: 3}
+  m_Name: Backpack
+  m_EditorClassIdentifier: 
+  size: {x: 2, y: 2}
+  icon: {fileID: 0}
+  worldObject: {fileID: 0}
+  itemStorageSize: {x: 4, y: 4}
+  itemBlacklist: []
+  blacklistIsWhitelist: 0
+  insulation: 0

--- a/Examples/Items/Backpack.asset.meta
+++ b/Examples/Items/Backpack.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 640e2a11a4d075d40b4a181d4f21a78c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/User Interface/InventoryUIManager.cs
+++ b/User Interface/InventoryUIManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace KoalaDev.UGIS.UI
 {
@@ -15,6 +16,10 @@ namespace KoalaDev.UGIS.UI
 
         [SerializeField] private Transform heldItemContainer;
 
+        public List<InventoryGrid> managedGrids;
+
+        public List<Item> startingItems;
+
         #endregion
 
         #region --- MONOBEHAVIOUR ---
@@ -27,8 +32,20 @@ namespace KoalaDev.UGIS.UI
             }
             
             Instance = this;
+
+            foreach (InventoryGrid grid in managedGrids)
+            {
+                grid.AutoAddItem(new InventoryItem(startingItems[Random.Range(0, startingItems.Count)], null, grid));
+                grid.AutoAddItem(new InventoryItem(startingItems[Random.Range(0, startingItems.Count)], null, grid));
+                grid.AutoAddItem(new InventoryItem(startingItems[Random.Range(0, startingItems.Count)], null, grid));
+            }
         }
-        
+
+        private void Start()
+        {
+            
+        }
+
         private void Update()
         {
             if (heldItem != null)


### PR DESCRIPTION
This item type is used to give inherited items a durability, useful for items such as weapons which may degrade over time.

Closes #21 

Additions
---
- **Damageable Item Type** - New abstract item type that allows child classes to have a durability.