### PR TITLE
Added UI support for container and stackable items.

### DIFF
--- a/Core/Editor/InventoryGridComponentEditor.cs
+++ b/Core/Editor/InventoryGridComponentEditor.cs
@@ -5,13 +5,12 @@ using UnityEngine;
 
 namespace InventorySystem.UI
 {
-    [CustomEditor(typeof(InventoryGrid))]
-
-    public class InventoryGridEditor : Editor
+    public class InventoryGridComponentEditor : Editor
     {
         #region --- VARIABLES ---
 
-        private InventoryGrid controller;
+        //private EDITORTYPE controller;
+        private InventoryGrid grid;
         
         private GUISkin skin;
 
@@ -24,6 +23,7 @@ namespace InventorySystem.UI
         #region - SERIALIZED -
 
         private SerializedObject soTarget;
+        private SerializedObject soGrid;
         
         private SerializedProperty gridSize;
 
@@ -55,7 +55,7 @@ namespace InventorySystem.UI
             // Inventory Grid Display
             GUILayout.Label( "Display", skin.GetStyle("header"));
             
-            Vector2Int size = controller.size;
+            Vector2Int size = grid.Size;
             float viewWidth = EditorGUIUtility.currentViewWidth - 10;
             scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
             Color defaultColour = GUI.color;
@@ -66,9 +66,9 @@ namespace InventorySystem.UI
                 GUILayout.FlexibleSpace();
                 for (int x = 0; x < size.x; x++)
                 {
-                    if (controller.ItemAtSlot(new Vector2Int(x, y)))
+                    if (grid.ItemAtSlot(new Vector2Int(x, y)))
                     {
-                        InventoryItem storedItem = controller.GetItemAtSlot(new Vector2Int(x, y));
+                        InventoryItem storedItem = grid.GetItemAtSlot(new Vector2Int(x, y));
                         if (storedItem != null)
                         {
                             Color color;
@@ -114,14 +114,16 @@ namespace InventorySystem.UI
         {
             skin = Resources.Load<GUISkin>("Skins/KoalaGUISkin");
             // --- Get Target ---
-            controller = (InventoryGrid)target;
+            //controller = (InventoryGridComponent)target;
             soTarget = new SerializedObject(target);
+
+            //grid = controller.Grid;
         }
 
         private void GetProperties()
         {
             // Inventory Grid Properties
-            gridSize = soTarget.FindProperty("size");
+            gridSize = soTarget.FindProperty("Grid").FindPropertyRelative("gridSize");
         }
 
         #endregion

--- a/Core/Editor/InventoryGridComponentEditor.cs.meta
+++ b/Core/Editor/InventoryGridComponentEditor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 42cc64575ceec7e4095cf9e4e437724e
+guid: 004447dc25df8534dbd7b56123ae2232
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Core/InventoryGrid.cs
+++ b/Core/InventoryGrid.cs
@@ -1,31 +1,32 @@
 using System.Collections.Generic;
 using System.Linq;
+using KoalaDev.UGIS.Items;
 using UnityEngine;
 
 namespace KoalaDev.UGIS
 {
-    public class InventoryGrid : MonoBehaviour
+    public class InventoryGrid
     {
         #region --- VARIABLES ---
 
-        public Vector2Int size = Vector2Int.one;
+        public Vector2Int Size;
         private readonly Dictionary<Vector2Int, InventoryItem> items = new ();
+        public readonly List<InventoryItem> ItemBlacklist = new ();
+        
+        public IEnumerable<InventoryItem> AllItems => new HashSet<InventoryItem>(items.Values).ToArray();
 
         #endregion
         
         #region --- METHODS ---
-        
-        public InventoryItem[] GetAllItems()
-        {
-            return new HashSet<InventoryItem>(items.Values).ToArray();
-        }
 
         #region - ADDING ITEMS -
 
         // Add item to specified position, if not obstructed.
-        public bool AddItemAtPosition(InventoryItem invItem, Vector2Int position)
+        public bool AddItemAtPosition(InventoryItem invItem, Vector2Int position, bool stackItems = true)
         {
             List<Vector2Int> itemSlots = new ();
+
+            if (ItemBlacklist.Contains(invItem)) return false;
 
             RemoveItem(invItem); // Removing Item from this Grid, if it's inside it.
 
@@ -35,8 +36,20 @@ namespace KoalaDev.UGIS
                 {
                     Vector2Int newPos = new (x, y);
 
-                    if (items.ContainsKey(newPos) || newPos.x >= size.x || newPos.y >= size.y || newPos.x < 0 || newPos.y < 0) return false;
+                    if (newPos.x >= Size.x || newPos.y >= Size.y || newPos.x < 0 || newPos.y < 0) return false;
 
+                    // Try to stack item if possible.
+                    if (items.ContainsKey(newPos))
+                    {
+                        if(stackItems && items[newPos].Item == invItem.Item)
+                            (items[newPos], invItem) = items[newPos].Item.ItemToItem(items[newPos], invItem);
+
+                        if (invItem != null) return false;
+                        
+                        items[newPos].Item.Updated();
+                        return true;
+                    }
+                    
                     itemSlots.Add(newPos);
                 }
             }
@@ -57,10 +70,12 @@ namespace KoalaDev.UGIS
         // Search through entire grid to find possible place, if none return false.
         public bool AutoAddItem(InventoryItem invItem)
         {
+            if (ItemBlacklist.Contains(invItem)) return false;
+            
             // Go through every slot, except those where the item couldn't fit anyway.
-            for (int y = 0; y < size.y - (invItem.Item.size.y - 1); y++)
+            for (int y = 0; y < Size.y - (invItem.Item.size.y - 1); y++)
             {
-                for (int x = 0; x < size.x - (invItem.Item.size.x - 1); x++)
+                for (int x = 0; x < Size.x - (invItem.Item.size.x - 1); x++)
                 {
                     // Attempting to add item at new position, returns true if item added successfully.
                     if (AddItemAtPosition(invItem, new Vector2Int(x, y))) return true;
@@ -114,6 +129,15 @@ namespace KoalaDev.UGIS
         public InventoryItem GetItemAtSlot(Vector2Int slot) => items[slot];
 
         #endregion
+
+        #endregion
+
+        #region --- CONSTRUCTOR ---
+
+        public InventoryGrid(Vector2Int size)
+        {
+            this.Size = size;
+        }
 
         #endregion
     }

--- a/Core/InventoryItem.cs
+++ b/Core/InventoryItem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using UnityEditor;
 using UnityEngine;
 
 namespace KoalaDev.UGIS
@@ -35,11 +36,13 @@ namespace KoalaDev.UGIS
 
         #region --- CONSTRUCTOR ---
         
-        public InventoryItem(Item item, Vector2Int[] takenSlots, InventoryGrid parentGrid)
+        public InventoryItem(Item item, InventoryGrid parentGrid, Vector2Int[] takenSlots = null, AdditionalItemData itemData = null)
         {
             Item = item;
             TakenSlots = takenSlots;
             this.parentGrid = parentGrid;
+            
+            ItemData = itemData ?? Item.GetAdditionalData;
         }
 
         #endregion

--- a/Data/Items/Base Types/Container.cs
+++ b/Data/Items/Base Types/Container.cs
@@ -17,14 +17,16 @@ namespace KoalaDev.UGIS.Items
         
         // Makes itemBlacklist a whitelist, meaning only items in the list can be added.
         public bool blacklistIsWhitelist; 
+        
+        public override AdditionalItemData GetAdditionalData => new ContainerItemData();
 
         #endregion
     }
 
     [Serializable]
-    public abstract class ContainerItemData : AdditionalItemData
+    public class ContainerItemData : AdditionalItemData
     {
-        private InventoryGrid containerGrid;
+        public InventoryGrid containerGrid;
     }
 
 }

--- a/Data/Items/Base Types/Damageable.cs
+++ b/Data/Items/Base Types/Damageable.cs
@@ -12,10 +12,16 @@ namespace KoalaDev.UGIS.Items
         public int maxDurability = 100;
 
         #endregion
+
+        #region --- METHODS ---
+
+        public override AdditionalItemData GetAdditionalData => new DamageableItemData();
+
+        #endregion
     }
 
     [Serializable]
-    public abstract class DamageableItemData : AdditionalItemData
+    public class DamageableItemData : AdditionalItemData
     {
         public float currentDurability;
     }

--- a/Data/Items/Base Types/Stackable.cs
+++ b/Data/Items/Base Types/Stackable.cs
@@ -16,11 +16,41 @@ namespace KoalaDev.UGIS.Items
         public int stackCapacity;
 
         #endregion
+
+        #region --- METHODS ---
+        public override AdditionalItemData GetAdditionalData => new StackableItemData();
+
+        public override (InventoryItem, InventoryItem) ItemToItem(InventoryItem invItem1, InventoryItem invItem2)
+        {
+            // --- RETURN CLAUSES ---
+            
+            // Return if either item doesn't exist
+            if (invItem1 == null || invItem2 == null) return (invItem1, invItem2);
+            // Return if items aren't the same
+            if (invItem1.Item != invItem2.Item) return (invItem1, invItem2);
+            // Return if the target is not stackable
+            if (invItem1.Item is not Stackable stackItem) return (invItem1, invItem2);
+            
+            // --- LOGIC ---
+            
+            // Getting Stackable Item Data.
+            StackableItemData stackData = (StackableItemData)invItem1.ItemData;
+
+            // If no space, return.
+            if (stackData.currentStackCount >= stackItem.stackCapacity) return (invItem1, invItem2);
+
+            // Incrementing Stack Count
+            stackData.currentStackCount += ((StackableItemData)invItem2.ItemData).currentStackCount;
+            
+            return (invItem1, null);
+        }
+
+        #endregion
     }
 
     [Serializable]
-    public abstract class StackableItemData : AdditionalItemData
+    public class StackableItemData : AdditionalItemData
     {
-        public int currentStackCount;
+        public int currentStackCount = 1;
     }
 }

--- a/Data/Items/Item.cs
+++ b/Data/Items/Item.cs
@@ -10,19 +10,33 @@ namespace KoalaDev.UGIS
     {
         #region --- VARIABLES ---
 
-        [Header("Item Properties")]
-        public Vector2Int size = Vector2Int.one;
+        [Header("Item Properties")] public Vector2Int size = Vector2Int.one;
         public Sprite icon;
         public GameObject worldObject;
-
+        
         // Stores all the possible interactions related to the item.
-        public InteractionProfile InteractionProfile;
+        public InteractionProfile interactionProfile;
+        
+        // --- EVENTS ---
+        public event Action OnUpdate;
+
+        #endregion
+        
+        #region --- METHODS ---
+
+        public virtual AdditionalItemData GetAdditionalData => new ();
+        public virtual (InventoryItem, InventoryItem) ItemToItem(InventoryItem invItem1, InventoryItem invItem2) { return (invItem1, invItem2); }
+
+        public void Updated()
+        {
+            OnUpdate?.Invoke();
+        }
 
         #endregion
     }
-    
+
     [Serializable]
-    public abstract class AdditionalItemData
+    public class AdditionalItemData
     {
         
     }

--- a/Data/Items/Weapons/Attachments/Magazine.cs
+++ b/Data/Items/Weapons/Attachments/Magazine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -17,6 +18,8 @@ namespace KoalaDev.UGIS.Items.WeaponSystem
         #endregion
 
         #region --- METHODS ---
+
+        #region - MAGAZINE UTILITIES -
 
         // Clears, then Fills magazine to given value OR max capacity.
         public static void FillMagazine(Magazine mag, MagazineItemData magData, Bullet bullet, int count = 0)
@@ -50,13 +53,61 @@ namespace KoalaDev.UGIS.Items.WeaponSystem
             return bullet;
         }
 
+        public static Bullet[] UnloadMagazine(MagazineItemData magazineData)
+        {
+            Bullet[] bullets = magazineData.MagazineStack.ToArray();
+
+            magazineData.MagazineStack.Clear();
+            
+            return bullets;
+        }
+
+        #endregion
+        
+        public override (InventoryItem, InventoryItem) ItemToItem(InventoryItem invItem1, InventoryItem invItem2)
+        {
+            // --- RETURN CLAUSES ---
+            
+            // Return if either item doesn't exist
+            if (invItem1 == null || invItem2 == null) return (invItem1, invItem2);
+            // Return if the target is not magazine
+            if (invItem1.Item is not Magazine magazineItem) return (invItem1, invItem2);
+            // Return if second item is not bullet.
+            if (invItem2.Item is not Bullet bulletItem) return (invItem1, invItem2);
+            // Return if Bullet is not an accepted Caliber.
+            if(!Array.Exists(magazineItem.acceptedCartridges, element => element == bulletItem.bulletCaliber)) 
+                return (invItem1, invItem2);
+
+            
+            // --- LOGIC ---
+            
+            StackableItemData bulletData = (StackableItemData)invItem2.ItemData;
+
+            for (int i = bulletData.currentStackCount; i > 0; i--)
+            {
+                if (LoadBullet(magazineItem, (MagazineItemData)invItem1.ItemData, bulletItem))
+                {
+                    bulletData.currentStackCount--;
+                }
+                else
+                {
+                    invItem2.ItemData = bulletData;
+                    return (invItem1, invItem2);
+                }
+            }
+
+            return (invItem1, null);
+        }
+        
+        public override AdditionalItemData GetAdditionalData => new MagazineItemData();
+
         #endregion
     }
 
     // Runtime Data for the Magazine Class.
     public class MagazineItemData : AdditionalItemData
     {
-        public Stack<Bullet> MagazineStack; // Index corresponds to position in magazine. First in, Last out
+        public Stack<Bullet> MagazineStack = new Stack<Bullet>(); // Index corresponds to position in magazine. First in, Last out
     }
 
 }

--- a/User Interface/InventoryUIContextButton.cs
+++ b/User Interface/InventoryUIContextButton.cs
@@ -15,7 +15,7 @@ public class InventoryUIContextButton : MonoBehaviour
     public Button btn;
     
     // Inventory Scripts
-    public InventoryInteraction action;
+    public InventoryInteractionChannel action;
     public InventoryUIContextMenu parentMenu;
 
     #endregion

--- a/User Interface/InventoryUIContextMenu.cs
+++ b/User Interface/InventoryUIContextMenu.cs
@@ -22,23 +22,18 @@ namespace KoalaDev.UGIS.UI
         #endregion
 
         #region --- METHODS ---
-
-        public InventoryUIContextMenu(InventoryUIItem invUIItem)
-        {
-            this.invUIItem = invUIItem;
-        }
-
+        
         private void Generate()
         {
-            if (invUIItem.InvItem.Item.InteractionProfile.Interactions.Length <= 0) 
+            if (invUIItem.InvItem.Item.interactionProfile.Interactions.Length <= 0) 
                 Destroy(gameObject);
             
-            InventoryInteraction[] interactions = (from interaction in invUIItem.InvItem.Item.InteractionProfile.Interactions
+            InventoryInteractionChannel[] interactions = (from interaction in invUIItem.InvItem.Item.interactionProfile.Interactions
                 where interaction != null
-                where interaction.GetType() == typeof(InventoryInteraction)
-                select (InventoryInteraction)interaction).ToArray();
+                where interaction.GetType() == typeof(InventoryInteractionChannel)
+                select (InventoryInteractionChannel)interaction).ToArray();
 
-            foreach (InventoryInteraction interaction in interactions)
+            foreach (InventoryInteractionChannel interaction in interactions)
             {
                 InventoryUIContextButton interactionBtn = Instantiate(invUIItem.uiGrid.GetStyle.actionObj, transform).GetComponent<InventoryUIContextButton>();
                 interactionBtn.action = interaction;
@@ -50,7 +45,6 @@ namespace KoalaDev.UGIS.UI
         public static void RemoveMenu()
         {
             InventoryUIManager.Instance.RemoveContextMenu();
-            
         }
 
         #endregion

--- a/User Interface/InventoryUIGrid.cs
+++ b/User Interface/InventoryUIGrid.cs
@@ -11,19 +11,25 @@ namespace KoalaDev.UGIS.UI
         #region --- VARIABLES ---
 
         // --- Backend ---
-        [SerializeField] private InventoryGrid grid;
+        private InventoryGrid grid;
 
         // --- User Interface ---
         [SerializeField] private InventoryUIStyle style;
-        [SerializeField] private bool generateOnStart;
-        
+        [SerializeField] private bool generateOnStart = false;
+
         // - Components -
+        private Transform gridTransform;
         private GridLayoutGroup gridLayout;
         private ContentSizeFitter sizeFitter;
 
         // - Generated Objects -
-        private readonly Dictionary<Vector2Int, InventoryUISlot> slots = new ();
-        private readonly Dictionary<GameObject, InventoryUIItem> items = new ();
+        private readonly Dictionary<Vector2Int, InventoryUISlot> slots = new();
+        private readonly Dictionary<GameObject, InventoryUIItem> items = new();
+        
+        // - TEMP -
+        public Vector2Int size;
+        public List<Item> startingItems;
+
 
         #endregion
 
@@ -32,29 +38,38 @@ namespace KoalaDev.UGIS.UI
         private void Awake()
         {
             Init();
+
+            if (startingItems is { Count: > 0 })
+            {
+                for (int i = 0; i < 12; i++)
+                {
+                    grid.AutoAddItem(new InventoryItem(startingItems[Random.Range(0, startingItems.Count)], grid));
+                }
+            }
         }
 
         private void Start()
         {
-            if(generateOnStart) Generate();
+            if (generateOnStart) Generate();
         }
 
         #endregion
 
         #region --- METHODS ---
-        
+
         private void Init()
         {
-            // Return if no grid found.
-            if (grid == null && !TryGetComponent(out grid)) return;
+            grid ??= new InventoryGrid(size);
+            
+            if (gridTransform == null) gridTransform = transform;
             
             // Getting Required Front-end Elements.
-            gridLayout = GetComponent<GridLayoutGroup>(); //Getting Grid Layout
+            gridLayout = gridTransform.GetComponent<GridLayoutGroup>(); //Getting Grid Layout
 
             // Setting Grid Constraints
             gridLayout.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
-            gridLayout.constraintCount = grid.size.x;
-            
+            gridLayout.constraintCount = grid.Size.x;
+
             //Attempting to Get Size Fitter
             if (TryGetComponent(out sizeFitter))
             {
@@ -64,14 +79,15 @@ namespace KoalaDev.UGIS.UI
         }
 
         #region - GRID GENERATION -
-        
-        // Generate Grid
+
+        // Generate UI Grid
         public void Generate()
         {
             ClearGrid();
-            for (int y = 0; y < grid.size.y; y++)
+            grid ??= new InventoryGrid(size);
+            for (int y = 0; y < grid.Size.y; y++)
             {
-                for (int x = 0; x < grid.size.x; x++)
+                for (int x = 0; x < grid.Size.x; x++)
                 {
                     // --- Create Slot Object ---
                     GameObject slotObj = Instantiate(style.slotObj, transform);
@@ -82,30 +98,30 @@ namespace KoalaDev.UGIS.UI
                     {
                         slotComponent = slotObj.AddComponent<InventoryUISlot>();
                     }
-                    
-                    Vector2Int slotPos = new (x, y);
+
+                    Vector2Int slotPos = new(x, y);
 
                     // --- Update Slot Component Values ---
                     slotComponent.slotPosition = slotPos;
                     slotComponent.grid = this;
-                    
+
                     slots.Add(slotPos, slotComponent);
                 }
             }
-            
+
             LayoutRebuilder.ForceRebuildLayoutImmediate(GetComponent<RectTransform>());
-            
-            foreach (InventoryItem invItem in grid.GetAllItems())
+
+            foreach (InventoryItem invItem in grid.AllItems)
             {
                 Item item = invItem.Item;
                 GameObject itemObj = Instantiate(style.itemObj, transform);
-                
+
                 // --- Add Item Component ---
                 if (!itemObj.TryGetComponent(out InventoryUIItem uiItem)) //Add Item Component if none exists
                 {
                     uiItem = itemObj.AddComponent<InventoryUIItem>();
                 }
-                
+
                 uiItem.InvItem = invItem;
                 uiItem.uiGrid = this;
 
@@ -114,14 +130,14 @@ namespace KoalaDev.UGIS.UI
                 {
                     slots[slot].GetComponent<InventoryUISlot>().containedItem = uiItem;
                 }
-                
+
                 items.Add(itemObj, uiItem);
 
                 // Set Rect Size to Match Grid Size
                 itemObj.GetComponent<RectTransform>().sizeDelta = new Vector2(
                     gridLayout.cellSize.x * item.size.x + gridLayout.spacing.x * (item.size.x - 1),
                     gridLayout.cellSize.y * item.size.y + gridLayout.spacing.y * (item.size.y - 1));
-                
+
                 // --- Set Position to Average Position of Slots. ---
                 itemObj.GetComponent<RectTransform>().anchoredPosition = GetAveragePosition(invItem.TakenSlots);
             }
@@ -130,16 +146,16 @@ namespace KoalaDev.UGIS.UI
         #endregion
 
         #region - GRID UTILITIES -
-        
+
         private void ClearGrid()
         {
             foreach (InventoryUISlot uiSlot in slots.Values)
             {
                 Destroy(uiSlot.gameObject);
             }
-            
+
             slots.Clear();
-            
+
             ClearItems();
         }
 
@@ -149,10 +165,10 @@ namespace KoalaDev.UGIS.UI
             {
                 Destroy(uiItem.gameObject);
             }
-            
+
             items.Clear();
         }
-        
+
         public bool RemoveItem(InventoryUIItem uiItem, bool destroyItem = false)
         {
             if (grid.RemoveItem(uiItem.InvItem))
@@ -161,19 +177,39 @@ namespace KoalaDev.UGIS.UI
                 {
                     slots[takenSlot].containedItem = null;
                 }
-                
+
                 items.Remove(uiItem.gameObject);
-                
-                if(destroyItem)
+
+                if (destroyItem)
                     Destroy(uiItem.gameObject);
-                
+
                 return true;
             }
 
             return false;
         }
 
-        public bool AddItemAtPosition(InventoryUIItem uiItem, Vector2Int pos)
+        public InventoryUIItem CreateUIItem(Item item)
+        {
+            if (item == null) return null;
+            
+            InventoryItem invItem = new InventoryItem(item, grid);
+            
+            GameObject itemObj = Instantiate(style.itemObj, transform);
+
+            // --- Add Item Component ---
+            if (!itemObj.TryGetComponent(out InventoryUIItem uiItem)) //Add Item Component if none exists
+            {
+                uiItem = itemObj.AddComponent<InventoryUIItem>();
+            }
+
+            uiItem.InvItem = invItem;
+            uiItem.uiGrid = this;
+            
+            return uiItem;
+        }
+
+        public bool AddUIItemAtPosition(InventoryUIItem uiItem, Vector2Int pos)
         {
             if (grid.AddItemAtPosition(uiItem.InvItem, pos))
             {
@@ -201,6 +237,39 @@ namespace KoalaDev.UGIS.UI
 
             return false;
         }
+        
+        public bool AutoAddUIItem(InventoryUIItem uiItem)
+        {
+            if (!grid.AutoAddItem(uiItem.InvItem)) return false;
+            
+            if (uiItem.InvItem?.TakenSlots == null || uiItem.InvItem.TakenSlots.Length == 0)
+            {
+                Destroy(uiItem.gameObject);
+                return false;
+            }
+                
+            uiItem.transform.SetParent(transform);
+            uiItem.uiGrid = this; //Set Item Parent Grid to New Grid
+
+            Item item = uiItem.InvItem.Item;
+                
+            // --- Set Rect Size to Match Grid Size, Including Spacing. ---
+            uiItem.GetComponent<RectTransform>().sizeDelta = new Vector2(
+                gridLayout.cellSize.x * item.size.x + gridLayout.spacing.x * (item.size.x - 1),
+                gridLayout.cellSize.y * item.size.y + gridLayout.spacing.y * (item.size.y - 1));
+                
+            uiItem.GetComponent<RectTransform>().anchoredPosition = GetAveragePosition(uiItem.InvItem.TakenSlots);
+                
+            // --- Update Slots ---
+            foreach (Vector2Int slot in uiItem.InvItem.TakenSlots)
+            {
+                slots[slot].GetComponent<InventoryUISlot>().containedItem = uiItem;
+            }
+                
+            items.Add(uiItem.gameObject, uiItem);
+            return true;
+
+        }
 
         // Assigns new grid and goes through GridUI initialization.
         public void AssignGrid(InventoryGrid newGrid, bool generateUI)
@@ -217,8 +286,16 @@ namespace KoalaDev.UGIS.UI
             }
         }
 
-        public InventoryUIStyle GetStyle => style;
+        public void DestroyGrid()
+        {
+            Destroy(gameObject);
+        }
 
+        public InventoryUIStyle GetStyle => style;
+        public InventoryUIStyle SetStyle(InventoryUIStyle newStyle) => style = newStyle;
+        
+        public InventoryGrid GetGrid => grid;
+        
         private Vector2 GetAveragePosition(IReadOnlyCollection<Vector2Int> input)
         {
             Vector2 sum = input.Aggregate(Vector2.zero,

--- a/User Interface/InventoryUIItem.cs
+++ b/User Interface/InventoryUIItem.cs
@@ -1,6 +1,10 @@
 using System;
 using KoalaDev.UGIS;
+using KoalaDev.UGIS.Items;
+using KoalaDev.UGIS.Items.WeaponSystem;
 using KoalaDev.UGIS.UI;
+using KoalaDev.Utilities.Data;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -13,6 +17,7 @@ public class InventoryUIItem : MonoBehaviour
 
     [SerializeField] private Image itemIcon;
     [SerializeField] private Image itemBackground;
+    [SerializeField] private TextMeshProUGUI stackCounterLabel;
 
     private Color backgroundColor;
 
@@ -22,21 +27,43 @@ public class InventoryUIItem : MonoBehaviour
 
     private void Start()
     {
-        if (itemIcon != null)
-        {
-            itemIcon.sprite = InvItem.Item.icon;
-        }
+        Init();
+        UpdateItem();
         
-        if (itemBackground == null)
-            TryGetComponent(out itemBackground);
+        InvItem.Item.OnUpdate += UpdateItem;
+    }
 
-        if (itemBackground != null) 
-            backgroundColor = itemBackground.color;
+    private void OnEnable()
+    {
+        if (InvItem != null)
+        {
+            InvItem.Item.OnUpdate += UpdateItem;
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (InvItem != null)
+        {
+            InvItem.Item.OnUpdate -= UpdateItem;
+        }
     }
 
     #endregion
 
     #region --- METHODS ---
+
+    private void Init()
+    {
+        if (itemIcon != null)
+            itemIcon.sprite = InvItem.Item.icon;
+
+        if (itemBackground == null)
+            TryGetComponent(out itemBackground);
+
+        if (itemBackground != null)
+            backgroundColor = itemBackground.color;
+    }
 
     public void Highlight(Color color)
     {
@@ -50,6 +77,23 @@ public class InventoryUIItem : MonoBehaviour
         if (itemBackground == null) return;
 
         itemBackground.color = backgroundColor;
+    }
+
+    public void UpdateItem()
+    {
+        UpdateStackCounter();
+    }
+
+    private void UpdateStackCounter()
+    {
+        if (stackCounterLabel == null) return;
+
+        stackCounterLabel.text = InvItem.ItemData switch
+        {
+            StackableItemData itemData => itemData.currentStackCount.ToString(),
+            MagazineItemData magazineData => magazineData.MagazineStack.Count.ToString(),
+            _ => ""
+        };
     }
 
     #endregion

--- a/User Interface/InventoryUIManager.cs
+++ b/User Interface/InventoryUIManager.cs
@@ -1,7 +1,12 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using KoalaDev.UGIS.Items;
+using KoalaDev.UI;
 using KoalaDev.Utilities.Data;
 using UnityEngine;
 using UnityEngine.UI;
+using Random = UnityEngine.Random;
 
 namespace KoalaDev.UGIS.UI
 {
@@ -9,25 +14,29 @@ namespace KoalaDev.UGIS.UI
     {
         #region --- VARIABLES ---
 
-        public static InventoryUIManager Instance;
+        public static InventoryUIManager Instance { get; private set; }
         
-        private HeldItemData heldItem;
-        private InventoryUIItem selectedItem;
+        // - Temporary - 
+        public List<Item> startingItems;
+        public List<InventoryGrid> managedGrids = new List<InventoryGrid>();
 
         [SerializeField] private Transform heldItemContainer;
-
-        public List<InventoryGrid> managedGrids;
-
-        public List<Item> startingItems;
-
-        [SerializeField] private Color highlightColour;
+        [SerializeField] private Transform gridObjContainer;
+        
+        // - Runtime Data -
+        private HeldItemData heldItem;
+        private InventoryUIItem selectedItem;
+        private InventoryUIContextMenu currentContextMenu;
+        private InventoryUIGrid lastAddedContainer;
+        private Dictionary<InventoryItem, UIWindow> openContainers = new Dictionary<InventoryItem, UIWindow>();
 
         #region - INTERACTIONS -
 
-        private InventoryUIContextMenu currentContextMenu;
+        [Header("Interaction Channels")] 
+        [SerializeField] private InteractionChannel dropItemInteractionChannel;
+        [SerializeField] private InteractionChannel openItemInteractionChannel;
 
-        public Interaction dropItemInteraction;
-        public Interaction equipItemInteraction;
+        private event Action<InventoryUIGrid> ItemMoved;
 
         #endregion
 
@@ -48,20 +57,10 @@ namespace KoalaDev.UGIS.UI
             {
                 for (int i = 0; i < 12; i++)
                 {
-                    grid.AutoAddItem(new InventoryItem(startingItems[Random.Range(0, startingItems.Count)], null, grid));
+                    grid.AutoAddItem(new InventoryItem(startingItems[Random.Range(0, startingItems.Count)], grid));
                 }
             }
 
-        }
-
-        private void OnEnable()
-        {
-            dropItemInteraction.Interact += DropItem;
-        }
-
-        private void OnDisable()
-        {
-            dropItemInteraction.Interact -= DropItem;
         }
 
         private void Update()
@@ -71,11 +70,21 @@ namespace KoalaDev.UGIS.UI
                 heldItem.UIItem.transform.position = Input.mousePosition + heldItem.MouseOffset;
             }
         }
+        
+        private void OnEnable()
+        {
+            SubscribeActions();
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeActions();
+        }
 
         #endregion
 
         #region --- METHODS ---
-
+        
         public void SlotClick(InventoryUISlot slot)
         {
             if (currentContextMenu != null)
@@ -83,7 +92,26 @@ namespace KoalaDev.UGIS.UI
                 InventoryUIContextMenu.RemoveMenu();
                 UnselectItem();
             }
-            
+
+            if (heldItem != null && slot.containedItem == true)
+            {
+                (InventoryItem slotInvItem, InventoryItem heldInvItem) = slot.containedItem.InvItem.Item.ItemToItem(slot.containedItem.InvItem, heldItem.UIItem.InvItem);
+
+                if (slotInvItem == null)
+                {
+                    Destroy(slot.containedItem.gameObject);
+                    slot.containedItem = null;
+                } else slot.containedItem.InvItem.Item.Updated();
+                
+                if (heldInvItem == null)
+                {
+                    Destroy(heldItem.UIItem.gameObject);
+                    heldItem = null;
+                } else heldItem.UIItem.InvItem.Item.Updated();
+                
+                return;
+            }
+
             if (heldItem == null && slot.containedItem != null)
             {
                 GrabItem(slot);
@@ -93,11 +121,24 @@ namespace KoalaDev.UGIS.UI
             if (heldItem != null)
             {
                 PlaceItem(slot);
+                return;
             }
         }
+
+        #region - ITEM MOVEMENT -
+
         private void GrabItem(InventoryUISlot slot) //Attaches the Item to the Mouse
         {
             if (heldItem != null) return;
+            
+            // Close Container window if picking up container item.
+            if (openContainers.ContainsKey(slot.containedItem.InvItem))
+            {
+                if (openContainers[slot.containedItem.InvItem] != null)
+                    openContainers[slot.containedItem.InvItem].Close();
+
+                openContainers.Remove(slot.containedItem.InvItem);
+            }
 
             InventoryUIItem invItem = slot.containedItem;
 
@@ -111,9 +152,21 @@ namespace KoalaDev.UGIS.UI
             {
                 invItem.transform.SetParent(heldItemContainer);
             }
-
+            
             invItem.uiGrid.RemoveItem(invItem);
         }
+
+        private void PlaceItem(InventoryUISlot slot) //Places Attached Item to Clicked Slot
+        {
+            if (openContainers.ContainsKey(heldItem.UIItem.InvItem)) return;
+            if(!slot.grid.AddUIItemAtPosition(heldItem.UIItem, slot.slotPosition - heldItem.GridOffset)) return;
+
+            heldItem = null;
+        }
+
+        #endregion
+
+        #region - ITEM SELECTION -
 
         private void SelectItem(InventoryUIItem item)
         {
@@ -125,37 +178,158 @@ namespace KoalaDev.UGIS.UI
             if (item == null) return;
 
             selectedItem = item; 
-            item.Highlight(highlightColour);
         }
 
         private void UnselectItem()
         {
             if (selectedItem == null) return;
             
-            // Remove Current Context Menu, This could cause problems?
+            // Remove Current Context Menu, This could cause problems? EDIT: CAN'T REMEMBER WHY THIS WOULD CAUSE PROBLEMS.
             if (currentContextMenu != null) Destroy(currentContextMenu);
 
             selectedItem.RemoveHighlight();
             selectedItem = null;
         }
-        
-        private void PlaceItem(InventoryUISlot slot) //Places Attached Item to Clicked Slot
-        {
-            if(!slot.grid.AddItemAtPosition(heldItem.UIItem, slot.slotPosition - heldItem.GridOffset)) return;
-            
-            heldItem = null;
-        }
+
+        #endregion
+
+        #region - ITEM FUNCTIONS -
 
         public void DropItem()
         {
             Debug.Log($"Dropped Item! {selectedItem.InvItem.Item.name}");
+            if (openContainers.ContainsKey(selectedItem.InvItem))
+            {
+                openContainers[selectedItem.InvItem].Close();
+            }
             selectedItem.uiGrid.RemoveItem(selectedItem, true);
             UnselectItem();
         }
 
+        public void OpenInventoryContainer()
+        {
+            if (openContainers.ContainsKey(selectedItem.InvItem))
+            {
+                if (openContainers[selectedItem.InvItem] != null) return; // Return if window still open.
+                
+                openContainers.Remove(selectedItem.InvItem);
+            }
+
+            UIWindowManager windowManager = UIWindowManager.Instance;
+
+            if (windowManager == null)
+            {
+                Debug.LogWarning("Warning: Can't open inventory container, no UI Window Manager in Scene.");
+                return;
+            }
+
+            UIWindow lastContainer = openContainers.LastOrDefault().Value;
+            Vector2 newContainerPos = Vector2.zero;
+
+            if (lastContainer != null)
+            {
+                newContainerPos = lastContainer.gameObject.transform.localPosition + new Vector3(50, -50);
+            }
+            
+            UIWindow window = windowManager.CreateWindow("Container", newContainerPos);
+
+            InventoryUIItem uiItem = selectedItem;
+            if (uiItem.InvItem.Item is not Container container) return;
+            
+            ContainerItemData itemData = (ContainerItemData)uiItem.InvItem.ItemData;
+            
+            GameObject gridObj = Instantiate(uiItem.uiGrid.GetStyle.gridObj, window.Content);
+
+            if (!TryGetComponent(out InventoryUIGrid uiGrid))
+            {
+                uiGrid = gridObj.AddComponent<InventoryUIGrid>();
+            }
+
+            if (lastAddedContainer == null)
+            {
+                gridObj.transform.position = new Vector2(Screen.width / 2, Screen.height / 2);
+            }
+            else
+            {
+                gridObj.transform.position = lastAddedContainer.transform.position + new Vector3(20, -20);
+            }
+
+            itemData.containerGrid ??= new InventoryGrid(container.itemStorageSize);
+
+            itemData.containerGrid.ItemBlacklist.Add(uiItem.InvItem);
+            uiGrid.SetStyle(uiItem.uiGrid.GetStyle);
+            uiGrid.AssignGrid(itemData.containerGrid, true);
+
+            lastAddedContainer = uiGrid;
+
+            openContainers.Add(uiItem.InvItem, window);
+            window.Closed += OnContainerClosed;
+        }
+
+        public void OnContainerClosed(UIWindow window)
+        {
+            ContainerItemData containerItemData = openContainers.Where(
+                container => container.Value == window).Select(
+                container => (ContainerItemData)container.Key.ItemData).FirstOrDefault();
+
+            if (containerItemData == null) return;
+
+            // Return Held Item to Container if Held Item's original grid is being closed.
+            if(heldItem != null && heldItem.UIItem.uiGrid.GetGrid == containerItemData.containerGrid)
+            {
+                heldItem.UIItem.uiGrid.AddUIItemAtPosition(heldItem.UIItem, heldItem.UIItem.InvItem.TakenSlots[0]);
+                heldItem = null;
+            }
+
+            // Closing Container Windows that are children of current window being closed, this is recursive.
+            List<InventoryItem> childContainers = 
+                openContainers.Keys.Where(item => containerItemData.containerGrid.ContainsItem(item)).ToList();
+            
+            for (int i = childContainers.Count - 1; i >= 0; i--)
+            {
+                if(openContainers[childContainers[i]] != null)
+                    openContainers[childContainers[i]].Close();
+                
+                openContainers.Remove(childContainers[i]);
+            }
+        }
+
+        /*private void UnloadMagazine()
+        {
+            if (selectedItem.InvItem.Item is not Magazine) return;
+
+            Bullet[] bullets = Magazine.UnloadMagazine((MagazineItemData)selectedItem.InvItem.ItemData);
+
+            foreach (Bullet bullet in bullets)
+            {
+                selectedItem.uiGrid.AutoAddUIItem(selectedItem.uiGrid.CreateUIItem(bullet));
+            }
+            
+            selectedItem.InvItem.Item.Updated();
+            UnselectItem();
+        }*/
+
+        #endregion
+
         #endregion
 
         #region --- ITEM ACTIONS ---
+
+        #region - SUBSCRIPTIONS -
+
+        private void SubscribeActions()
+        {
+            dropItemInteractionChannel.Interact += DropItem;
+            openItemInteractionChannel.Interact += OpenInventoryContainer;
+        }
+        
+        private void UnsubscribeActions()
+        {
+            dropItemInteractionChannel.Interact -= DropItem;
+            openItemInteractionChannel.Interact -= OpenInventoryContainer;  
+        }
+
+        #endregion
 
         #region - CONTEXT MENU -
 
@@ -207,8 +381,6 @@ namespace KoalaDev.UGIS.UI
         // Offsets
         public readonly Vector3 MouseOffset;
         public readonly Vector2Int GridOffset;
-        public readonly Vector2Int OriginalSlot;
-        public readonly InventoryUIGrid OriginalGrid;
 
         public HeldItemData(InventoryUIItem uiItem, Vector3 mouseOffset, Vector2Int gridOffset)
         {


### PR DESCRIPTION
Description
---
Many changes have been made to allow for the UI / Front-end to support container and stackable item types. The most important change is that the InventoryGrid script is no longer a MonoBehaviour, this is primarily because the InventoryGrid should persist after an Item container window has been closed. Whilst this may cause some annoyances later down the line, ultimately it will be for the better.

In order to accommodate these changes, I have created a UI framework that allows for new windows to be opened that are draggable. This will make creating new functionality much easier and will improve extensibility.  The UI framework is kept in a separate repository, as it will most likely be used for future projects.

Closes #19

Additions & Changes
---
- **Stackable Item UI** - Stackable items are now supported within the UI, Stackable items now have a counter text object on their item object that represents how many items can be stacked.
- **Container Item UI** - Containers are now supported within the UI, container items are opened via the context menu, which creates a new UI window using the UI framework I created, with a newly created InventoryUIGrid as it's contents.
- **General Refactoring** - Several Miscellaneous changes have been made to various areas in the code.